### PR TITLE
Add print to fix mystery shell issues

### DIFF
--- a/toriptables3.py
+++ b/toriptables3.py
@@ -77,6 +77,7 @@ DNSPort %s
           "%s" % self.tor_uid, "-j", "RETURN"])
     call(["iptables", "-t", "nat", "-A", "OUTPUT", "-p", "udp", "--dport",
           self.local_dnsport, "-j", "REDIRECT", "--to-ports", self.local_dnsport])
+    print()
 
     for net in self.non_tor:
       call(["iptables", "-t", "nat", "-A", "OUTPUT", "-d", "%s" % net, "-j",


### PR DESCRIPTION
This fixes the "seeming hang" from #9. Strangely print(end="", flush=True) and stdout.flush() do not work. Something has to be written to stdout to fix it. I don't know why.